### PR TITLE
Fix links to TestSuite repo in examples page

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,9 +285,9 @@ Follow these steps to add new example tables from the TestSuite repo
 
 ### Adding an OpenStudio Simulation Use Case from the TestSuite repo
 
-1. The relevant files are currently on the L000_Schematron branch of the [TestSuite](https://github.com/BuildingSync/TestSuite/tree/L100_Schematron) repo.  Clone the repo locally.
-1. OpenStudio Simulation use case schematron files include patterns from a [library of schematron files](https://github.com/BuildingSync/TestSuite/tree/L100_Schematron/lib).  Copy these files from the TestSuite repo into the selection-tool at the following location: ```bsyncviewer/testsuitelib```.
-1. Open the relevant use case file from the TestSuite repo.  For example: [L00_OpenStudio_Simulation.sch](https://github.com/BuildingSync/TestSuite/blob/L100_Schematron/spec/use_cases/schema2.0.0/L000_OpenStudio_Simulation.sch).  Edit the include statements at the top of the file with relative paths to the selection-tool testsuitelib directory.  Save the file.
+1. The relevant files are currently on the `develop` branch of the [TestSuite](https://github.com/BuildingSync/TestSuite/tree/develop) repo.  Clone the repo locally.
+1. OpenStudio Simulation use case schematron files include patterns from a [library of schematron files](https://github.com/BuildingSync/TestSuite/tree/develop/lib).  Copy these files from the TestSuite repo into the selection-tool at the following location: ```bsyncviewer/testsuitelib```.
+1. Open the relevant use case file from the TestSuite repo.  For example: [L00_OpenStudio_Simulation.sch](https://github.com/BuildingSync/TestSuite/blob/develop/schematron/v2.2.0/v2-2-0_L000_OpenStudio_Simulation.sch).  Edit the include statements at the top of the file with relative paths to the selection-tool testsuitelib directory.  Save the file.
     ```bash
       <include href="../../testsuitelib/rootElements.sch#root.oneOfEachUntilBuilding"/>
       <include href="../../testsuitelib/rootElements.sch#root.oneOfEachFacilityUntilScenario"/>
@@ -303,5 +303,5 @@ Follow these steps to add new example tables from the TestSuite repo
     1. Upload the file that was modified in the previous step
     1. Save
 1. Make the use case public from the selection-tool admin interface.
-1. If you have any example files to add to the selection-tool (for example, for the L000 OpenStudio Simulation use case, there are [2 examples files](https://github.com/BuildingSync/TestSuite/tree/L100_Schematron/spec/use_cases/schema2.0.0/examples)), add them in the appropriate schema directory in ```bsyncviewer/lib/validator/examples```. Regenerate the ```example_files.zip``` archive.  This will make the files available as examples at the ```/validator``` URL.
+1. If you have any example files to add to the selection-tool (for example, for the L000 OpenStudio Simulation use case, there are [2 examples files](https://github.com/BuildingSync/TestSuite/tree/develop/spec/use_cases/schema2.0.0/examples)), add them in the appropriate schema directory in ```bsyncviewer/lib/validator/examples```. Regenerate the ```example_files.zip``` archive.  This will make the files available as examples at the ```/validator``` URL.
 1. You can now validate XMLs against the new use case.

--- a/bsyncviewer/templates/examples.html
+++ b/bsyncviewer/templates/examples.html
@@ -66,7 +66,7 @@
 
     <!--start copy from TestSuite README -->
     <h3 id="hvac-system-examples">HVAC System Examples</h3>
-    <p>Where the System Type specified below does not exactly match the enumeration in the BSync XML file, check the mapping defined by <a href="https://github.com/BuildingSync/BuildingSync-gem/blob/bb52655ebb8efeca44249277d3fb67ac60b4e610/lib/buildingsync/model_articulation/hvac_system.rb#L121-L143">map_primary_hvac_system_type_to_cbecs_system_type</a>. Additionally, see the <a href="https://github.com/BuildingSync/TestSuite/tree/L100_Schematron/examples/HVACSystems">examples/HVACSystems</a> directory for a tutorial and example files.</p>
+    <p>Where the System Type specified below does not exactly match the enumeration in the BSync XML file, check the mapping defined by <a href="https://github.com/BuildingSync/BuildingSync-gem/blob/bb52655ebb8efeca44249277d3fb67ac60b4e610/lib/buildingsync/model_articulation/hvac_system.rb#L121-L143">map_primary_hvac_system_type_to_cbecs_system_type</a>. Additionally, see the <a href="https://github.com/BuildingSync/TestSuite/tree/develop/examples/HVACSystems">examples/HVACSystems</a> directory for a tutorial and example files.</p>
     <table>
     <colgroup>
     <col width="35%" />
@@ -94,51 +94,51 @@
     </thead>
     <tbody>
     <tr class="odd">
-    <td><a href="https://github.com/BuildingSync/TestSuite/blob/L100_Schematron/spec/use_cases/schema2.0.0/examples/L000_OpenStudio_Simulation_01.xml">L000_OpenStudio_Simulation_01.xml</a></td>
+    <td><a href="https://github.com/BuildingSync/TestSuite/blob/develop/schematron/v2.2.0/examples/L000_OpenStudio_Simulation_01.xml">L000_OpenStudio_Simulation_01.xml</a></td>
     <td>Building</td>
     <td>VAV with reheat</td>
     <td>TRUE</td>
     <td>TRUE</td>
     <td>L000</td>
     <td>OpenStudio Simulation</td>
-    <td><a href="https://github.com/BuildingSync/TestSuite/blob/L100_Schematron/spec/use_cases/schema2.0.0/L000_OpenStudio_Simulation.sch">L000 OpenStudio Simulation</a></td>
+    <td><a href="https://github.com/BuildingSync/TestSuite/blob/develop/schematron/v2.2.0/v2-2-0_L000_OpenStudio_Simulation.sch">L000 OpenStudio Simulation</a></td>
     <td>No system-type actually declared. System inferred from OpenStudio Standards based on Building's OccupancyClassification and Gross floor area.</td>
     </tr>
     <tr class="even">
-    <td><a href="https://github.com/BuildingSync/TestSuite/blob/L100_Schematron/spec/use_cases/schema2.0.0/examples/L000_OpenStudio_Simulation_02.xml">L000_OpenStudio_Simulation_02.xml</a></td>
+    <td><a href="https://github.com/BuildingSync/TestSuite/blob/develop/schematron/v2.2.0/examples/L000_OpenStudio_Simulation_02.xml">L000_OpenStudio_Simulation_02.xml</a></td>
     <td>Building</td>
     <td>PSZ-AC with gas reheat</td>
     <td>TRUE</td>
     <td>TRUE</td>
     <td>L000</td>
     <td>OpenStudio Simulation</td>
-    <td><a href="https://github.com/BuildingSync/TestSuite/blob/L100_Schematron/spec/use_cases/schema2.0.0/L000_OpenStudio_Simulation.sch">L000 OpenStudio Simulation</a></td>
+    <td><a href="https://github.com/BuildingSync/TestSuite/blob/develop/schematron/v2.2.0/v2-2-0_L000_OpenStudio_Simulation.sch">L000 OpenStudio Simulation</a></td>
     <td>No system-type actually declared. System inferred from OpenStudio Standards based on Building's OccupancyClassification and Gross floor area.</td>
     </tr>
     <tr class="odd">
-    <td><a href="https://github.com/BuildingSync/TestSuite/blob/L100_Schematron/spec/use_cases/schema2.0.0/examples/L100_OpenStudio_Simulation_01.xml">L100_OpenStudio_Simulation_01.xml</a></td>
+    <td><a href="https://github.com/BuildingSync/TestSuite/blob/develop/schematron/v2.2.0/examples/L100_OpenStudio_Simulation_01.xml">L100_OpenStudio_Simulation_01.xml</a></td>
     <td>Section-Retail</td>
     <td>PSZ-AC with gas reheat</td>
     <td>TRUE</td>
     <td>TRUE</td>
     <td>L100</td>
     <td>OpenStudio Simulation</td>
-    <td><a href="https://github.com/BuildingSync/TestSuite/blob/L100_Schematron/spec/use_cases/schema2.0.0/L100_OpenStudio_Simulation.sch">L000 OpenStudio Simulation</a></td>
+    <td><a href="https://github.com/BuildingSync/TestSuite/blob/develop/schematron/v2.2.0/v2-2-0_L100_OpenStudio_Simulation.sch">L000 OpenStudio Simulation</a></td>
     <td>Packaged Rooftop Air Conditioner is mapped to PSZ-AC with gas reheat.</td>
     </tr>
     <tr class="even">
-    <td><a href="https://github.com/BuildingSync/TestSuite/blob/L100_Schematron/spec/use_cases/schema2.0.0/examples/L100_OpenStudio_Simulation_01.xml">L100_OpenStudio_Simulation_01.xml</a></td>
+    <td><a href="https://github.com/BuildingSync/TestSuite/blob/develop/schematron/v2.2.0/examples/L100_OpenStudio_Simulation_01.xml">L100_OpenStudio_Simulation_01.xml</a></td>
     <td>Section-Office</td>
     <td>PVAV with PFP boxes</td>
     <td>TRUE</td>
     <td>TRUE</td>
     <td>L100</td>
     <td>OpenStudio Simulation</td>
-    <td><a href="https://github.com/BuildingSync/TestSuite/blob/L100_Schematron/spec/use_cases/schema2.0.0/L100_OpenStudio_Simulation.sch">L000 OpenStudio Simulation</a></td>
+    <td><a href="https://github.com/BuildingSync/TestSuite/blob/develop/schematron/v2.2.0/v2-2-0_L100_OpenStudio_Simulation.sch">L000 OpenStudio Simulation</a></td>
     <td>Packaged Rooftop VAV with Electric Reheat is mapped as PVAV with PFP boxes</td>
     </tr>
     <tr class="odd">
-    <td><a href="https://github.com/BuildingSync/TestSuite/blob/L100_Schematron/examples/HVACSystems/PSZ-AC-CDM-001.xml">PSZ-AC-CDM-001.xml</a></td>
+    <td><a href="https://github.com/BuildingSync/TestSuite/blob/develop/examples/HVACSystems/PSZ-AC-CDM-001.xml">PSZ-AC-CDM-001.xml</a></td>
     <td>Section</td>
     <td>PSZ-AC</td>
     <td>N/A</td>
@@ -149,7 +149,7 @@
     <td>Example of constructing more complex, L200 system.</td>
     </tr>
     <tr class="even">
-    <td><a href="https://github.com/BuildingSync/TestSuite/blob/L100_Schematron/examples/HVACSystems/PSZ-HP-CDM-001.xml">PSZ-HP-CDM-001.xml</a></td>
+    <td><a href="https://github.com/BuildingSync/TestSuite/blob/develop/examples/HVACSystems/PSZ-HP-CDM-001.xml">PSZ-HP-CDM-001.xml</a></td>
     <td>Section</td>
     <td>PSZ-HP</td>
     <td>N/A</td>


### PR DESCRIPTION
Old links pointed to old branch. New links point to new branch.