### PR TITLE
refactor(validator): use TestSuite repo schematron validator

### DIFF
--- a/bsyncviewer/lib/validator/workflow.py
+++ b/bsyncviewer/lib/validator/workflow.py
@@ -2,40 +2,9 @@ import copy
 from collections import OrderedDict
 
 import xmlschema
+from tools.validate_sch import validate_schematron
 from bsyncviewer.models.schema import Schema
 from bsyncviewer.models.use_case import UseCase
-from lxml import etree, isoschematron
-
-
-def validate_schematron(schematron_path, document_path):
-    schematron_tree = etree.parse(schematron_path)
-    schematron = isoschematron.Schematron(schematron_tree, store_report=True)
-    document_tree = etree.parse(document_path)
-
-    schematron.validate(document_tree)
-
-    failed_assert_xpath = '/svrl:schematron-output/svrl:failed-assert'
-    failed_asserts = schematron.validation_report.xpath(
-        failed_assert_xpath,
-        namespaces={
-            'svrl': 'http://purl.oclc.org/dsdl/svrl'
-        })
-
-    errors = []
-    for failed_assert in failed_asserts:
-        # location stores an xpath to the element which failed validation
-        location = failed_assert.get('location')
-        failed_element = document_tree.xpath(location)[0]
-        # use namespace to make it pretty
-        tag = failed_element.tag.replace("{http://buildingsync.net/schemas/bedes-auc/2019}", "auc:")
-        # grab the message from failed_assert's first child
-        error_message = failed_assert[0].text
-        errors.append({
-            'line': failed_element.sourceline,
-            'element': tag,
-            'message': error_message
-        })
-    return errors
 
 
 class ValidationWorkflow(object):
@@ -190,9 +159,9 @@ class ValidationWorkflow(object):
 
         return results
 
-    def process_errors(self, results):
-        def format_error(error):
-            return f'line {error["line"]}: element {error["element"]}: {error["message"]}'
+    def process_errors(self, failures):
+        def format_failure(failure):
+            return f'line {failure.line}: element {failure.element}: {failure.message}'
 
         # separate INFO, WARNING, ERROR
 
@@ -201,15 +170,15 @@ class ValidationWorkflow(object):
         final_results['warnings'] = []
         final_results['errors'] = []
 
-        for res in results:
-            if '[INFO]' in res['message']:
+        for failure in failures:
+            if failure.role == 'INFO':
                 # append to info
-                final_results['infos'].append(format_error(res))
-            elif '[WARNING]' in res['message']:
+                final_results['infos'].append(format_failure(failure))
+            elif failure.role == 'WARNING':
                 # append to warnings
-                final_results['warnings'].append(format_error(res))
+                final_results['warnings'].append(format_failure(failure))
             else:
                 # assume error
-                final_results['errors'].append(format_error(res))
+                final_results['errors'].append(format_failure(failure))
 
         return final_results

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,6 @@ tox==3.14.1
 
 # string matching
 jellyfish==0.7.1
+
+# schematron runner from TestSuite repo
+git+git://github.com/BuildingSync/TestSuite.git@d30138ae537a58e53c4ec5dc04521c1d063f4889


### PR DESCRIPTION
## Changes
Add the TestSuite tool as a requirement and use it's validator for validating schematron files

## Manual Tests
Run the validator with the old schematron file types (those that include the failure severity in the message, ie `[ERROR] my message`) and new ones like this: https://github.com/BuildingSync/TestSuite/blob/develop/schematron/v2.2.0/v2-2-0_L100_Audit.sch
Both should have the Warnings/Errors placed into the correct categories.