### PR TITLE
fix(schema_parser): ignore import tags when parsing

### DIFF
--- a/bsyncviewer/lib/schema_parser.py
+++ b/bsyncviewer/lib/schema_parser.py
@@ -147,7 +147,8 @@ class BuildingSyncSchemaProcessor(object):
                 if looking_for_type_name == ne.name:
                     found = True
                     break
-            if found:
+            # if a referenced element wasn't found, and it wasn't a gbxml element, fail here
+            if found or type_ref.ref_type.startswith('gbxml'):
                 continue
             raise Exception("Couldn't find reference %s" % looking_for_type_name)
         # print("All type refs were properly accounted.")
@@ -172,6 +173,9 @@ class BuildingSyncSchemaProcessor(object):
                 full_schema.attributes.append(self._read_attribute(child))
             elif child.tag.endswith('annotation'):
                 full_schema.annotations.append(self._read_annotation(child))
+            elif child.tag.endswith('import'):
+                # import tags are ignored
+                continue
             else:
                 raise Exception("Invalid tag type in _read_schema: " + child.tag)
         return full_schema


### PR DESCRIPTION
## Context
BuildingSync version 2.2.0 introduces elements from gbXML. Selection tool's schema parser cannot handle imported schemas, so it would fail

## Changes
- parser skips import elements
- parser doesn't try to validate elements that are references within the gbxml namespace

## Testing
- Try uploading the [2.2.0 version of BuildingSync](https://github.com/BuildingSync/schema/releases/tag/v2.2.0), then go to the tree viewer. You should see 5 gbxml elements under `//auc:Building//auc:ThermalZones/auc:ThermalZone/auc:Spaces/auc:Space` (can just use the search bar to search for gbxml).

## Notes
gbxml elements will now show up as `gbxml:***` in the tree viewer. These elements to _not_ include their child elements, so any users will have to refer to the gbxml documentation.