### PR TITLE
refactor: add data dict links to releases page

### DIFF
--- a/bsyncviewer/templates/releases.html
+++ b/bsyncviewer/templates/releases.html
@@ -35,7 +35,11 @@
                       <br/>
                       <a href="{{ release.docs_url }}">Full Docs</a>
                     </td>
-                    <td><a href="{{ release.data_dict_xlsx_url }}">Spreadsheet</a></td>
+                    <td>
+                      <a href="{% url 'measures' version=release.version %}">Measures</a><br/>
+                      <a href="{% url 'enumerations' version=release.version %}">Enumerations</a><br/>
+                      <a href="{{ release.data_dict_xlsx_url }}">Excel Spreadsheet</a>
+                    </td>
                 </tr>
                 {% endfor %}
               </table>


### PR DESCRIPTION
## changes
- add links to enumerations and measures page from /releases table

## screenshots
![Screen Shot 2021-07-09 at 2 44 47 PM](https://user-images.githubusercontent.com/18518728/125134238-4faece00-e0c4-11eb-8c32-538524a959f2.png)
