### PR TITLE
updating validation workflow for large # errors and other small tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,11 @@ To parse and map a new BEDES version:
     ```
     Note that you must run this command without the --save_to_db flag first, in order to create the CSV files.
 
+### Admin Interface
+
+Login to the admin interface at `/user/login`
+Admin interface is available at `/admin`
+
 ### Adding a new BuildingSync Schema Version
 
 Follow these steps to add a new schema version to the selection tool:

--- a/bsyncviewer/static/css/overrides.css
+++ b/bsyncviewer/static/css/overrides.css
@@ -24,6 +24,14 @@ p {
     margin-top: 1rem;
 }
 
+.red {
+    color: #d9534f;
+}
+
+.green {
+    color: #5cb85c;
+}
+
 .bg-blue {
     background-color: #005191 !important;
 }
@@ -154,4 +162,33 @@ footer .main-footer p {
 .big-margins {
   margin-top: 50px !important;
   margin-bottom: 50px !important;
+}
+
+.pad-bottom-med {
+    padding-bottom: 30px;
+}
+
+.wrap-it {
+    word-wrap: break-word;
+    border-bottom: 1px solid #ccc;
+    padding: 5px;
+}
+
+.val-res {
+    table-layout: fixed;
+    width:100%;
+    border-collapse: collapse;
+}
+
+.pb-10 {
+    padding-bottom: 10px;
+}
+
+.ptb-10 {
+    padding-top: 10px;
+    padding-bottom: 10px;
+}
+
+.pb-20 {
+    padding-bottom: 20px;
 }

--- a/bsyncviewer/templates/bsyncviewer/usecase_confirm_delete.html
+++ b/bsyncviewer/templates/bsyncviewer/usecase_confirm_delete.html
@@ -1,4 +1,7 @@
-{% extends 'base.html' %}
+{% extends 'base2.html' %}
+{% load bootstrap4 %}
+{% load staticfiles %}
+
 
 {% block title %}Delete Use Case{% endblock %}
 

--- a/bsyncviewer/templates/bsyncviewer/usecase_form.html
+++ b/bsyncviewer/templates/bsyncviewer/usecase_form.html
@@ -1,4 +1,6 @@
-{% extends 'base.html' %}
+{% extends 'base2.html' %}
+{% load bootstrap4 %}
+{% load staticfiles %}
 
 {% block title %}Add Use Case{% endblock %}
 

--- a/bsyncviewer/templates/validator_results.html
+++ b/bsyncviewer/templates/validator_results.html
@@ -1,14 +1,12 @@
-{% extends 'base.html' %}
+{% extends 'base2.html' %}
+{% load bootstrap4 %}
+{% load staticfiles %}
 
+{% block title %}Validation Results{% endblock %}
 
-{% block title %}BuildingSync Schema Viewer{% endblock %}
+{% block content %}
 
-{% block content_notitle %}
-
-  <div class="container">
-    <header class="major">
-      <h2>Validator Results</h2>
-    </header>
+  <div class="container pad-bottom-med">
 
     <div>
       <a href="{% url 'validator' %}" class="btn btn-sm btn-link"><span
@@ -17,7 +15,7 @@
 
     <div class="row">
       <div class="col-md-11 pad-left-50 pad-top-20">
-        <h3>FILE: {{ filename }}</h3>
+        <h3>File: {{ filename }}</h3>
         <p><strong>Schema version:</strong> {{ schema_version }}
           {% if validation_results.schema.valid is True %}
           <span class="label label-success pad-10">Valid</span> {% else %}
@@ -26,12 +24,12 @@
         {# <div>Valid? {{ validation_results.valid }}</div>#}
         {% if validation_results.schema.valid is False %}
           <div>
-            <h3>Issues <span class="label label-danger pad5">{{ validation_results.schema.errors|length }}</span></h3>
-            <table>
+            <h4>Issues <span class="label label-danger pad5">{{ validation_results.schema.errors|length }}</span></h4>
+            <table class="val-res">
               {% for err in validation_results.schema.errors %}
-                <tr>
-                  <td>{{ forloop.counter }}.</td>
-                  <td>{{ err.path }} <br/>
+                <tr class="wrap-it">
+                  <td class="ptb-10">{{ forloop.counter }}.</td>
+                  <td class="ptb-10">{{ err.path }} <br/>
                     {{ err.message }}</td>
                 </tr>
               {% endfor %}
@@ -39,7 +37,6 @@
           </div>
         {% endif %}
       </div>
-
     </div>
 
     {% if validation_results.schema.valid is True and validation_results.use_cases %}
@@ -50,7 +47,6 @@
       </div>
       <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
         {% for name, uc in validation_results.use_cases.items %}
-
           <div class="panel panel-default">
             <div class="panel-heading" role="tab" id="heading{{ name|cut:' '|cut:'#'|cut:'.' }}">
               <h4 class="panel-title">
@@ -64,43 +60,44 @@
             <div id="collapse{{ name|cut:' '|cut:'#'|cut:'.' }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading{{ name|cut:' '|cut:'#'|cut:'.' }}">
               <div class="panel-body">
                 <div>
-                  {% if uc.valid is True %}
-                    <h3>{# {{ name }} #}
+                  <h3 class="pb-20">{{ name }}
+                    {% if uc.valid is True %}
                       <span class="label label-success pad-10">Valid</span>
-  {#                  {% else %}#}
-  {#                    <span class="label label-danger pad-10">Invalid</span>#}
-                    </h3>
-                  {% endif %}
+                    {% else %}
+                      <span class="label label-danger pad-10">Invalid</span>
+                    {% endif %}
+                  </h3>
+
                   {% if uc.infos %}
-                    <h4>Info<span class="label label-info pad5">{{ uc.infos|length }}</span></h4>
-                    <table style="table-layout: fixed; ">
+                    <h4 class="pb-20">Info<span class="label label-info pad5">{{ uc.infos|length }}</span></h4>
+                    <table class="val-res">
                       {% for item in uc.infos %}
                         <tr class="wrap-it">
-                          <td width="5%">{{ forloop.counter }}.</td>
-                          <td class="wrap-it">{{ item }}</td>
+                          <td width="5%" class="ptb-10">{{ forloop.counter }}.</td>
+                          <td class="ptb-10">{{ item }}</td>
                         </tr>
                       {% endfor %}
                     </table>
                   {% endif %}
                   {% if uc.warnings %}
-                    <h4>Warnings<span class="label label-warning pad5">{{ uc.warnings|length }}</span></h4>
-                    <table style="table-layout: fixed; ">
+                    <h4 class="pb-20">Warnings<span class="label label-warning pad5">{{ uc.warnings|length }}</span></h4>
+                    <table class="val-res">
                       {% for item in uc.warnings %}
                         <tr class="wrap-it">
-                          <td width="5%">{{ forloop.counter }}.</td>
-                          <td class="wrap-it">{{ item }}</td>
+                          <td width="5%" class="ptb-10">{{ forloop.counter }}.</td>
+                          <td class="ptb-10">{{ item }}</td>
                         </tr>
                       {% endfor %}
                     </table>
                   {% endif %}
 
                   {%  if uc.valid is False %}
-                    <h4>Errors <span class="label label-danger pad5">{{ uc.errors|length }}</span></h4>
-                    <table style="table-layout: fixed; ">
+                    <h4 class="pb-20">Errors <span class="label label-danger pad5">{{ uc.errors|length }}</span></h4>
+                    <table class="val-res">
                       {% for err in uc.errors %}
                         <tr class="wrap-it">
-                          <td width="5%">{{ forloop.counter }}.</td>
-                          <td class="wrap-it">{{ err }}</td>
+                          <td width="5%" class="ptb-10">{{ forloop.counter }}.</td>
+                          <td class="ptb-10">{{ err }}</td>
                         </tr>
                       {% endfor %}
                     </table>
@@ -111,10 +108,9 @@
           </div>
         {%  endfor %}
       </div>
-      </div>
 
     {% endif %}
 
   </div>
 
-{% endblock content_notitle %}
+{% endblock content %}

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -19,6 +19,7 @@ server {
 
     # max upload size
     client_max_body_size 75M;   # adjust to taste
+    client_body_timeout 6000;
 
     location = /favicon.ico { access_log off; log_not_found off; }
     location /media  {
@@ -29,7 +30,7 @@ server {
     }
     location /documentation/ {
         alias /srv/selection-tool/bsyncviewer/media/generated_docs/;
-        try_files $uri.html =404; 
+        try_files $uri.html =404;
     }
 
     location / {

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ djangorestframework-xml==1.0.1
 lxml==4.6.3
 psycopg2==2.7.7
 semantic-version==2.8.5
+stopit==1.1.2
 xmlschema==1.0.15
 xmltodict==0.12.0
 
@@ -23,4 +24,3 @@ jellyfish==0.7.1
 
 # schematron runner from TestSuite repo
 testsuite==0.1.2
-


### PR DESCRIPTION
Fixes #129 

- several formatting fixes on the use case form page and validation results page
- hackish workaround for files that have a large # of errors...the to_dict() method times out on those errors, so bail out after 5mins (this timeout can be adjusted) and use the .validate() method instead which only returns the first error encountered.  